### PR TITLE
[#9] feature artifacts 기본 경로를 .claude/ccw/<feature>/로 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,10 @@ Prefix every commit message subject with `[#<issue_number>] ` to track the relat
 
 ## What lives elsewhere (not in this repo)
 
-When the `ccw` plugin is *used* (in some other project), it creates:
+When the `ccw` plugin is *used* (in some other project), it creates `.claude/ccw/<feature-name>/` containing:
 
-- `.claude/ccw/<feature-name>/state.json` — progress state for an in-progress feature
-- `.claude/ccw/<feature-name>/config.json` — verification commands for that feature
-- `docs/features/<feature-name>/design.md` and `plan.md` — feature artifacts
+- `state.json` — progress state for an in-progress feature
+- `config.json` — verification commands for that feature
+- `design.md` and `plan.md` — feature artifacts (default location; the user may pick an external destination like Confluence instead)
 
 These paths are mentioned here for context only. They never appear in this repo.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is my personal Claude Code workflow for developing a feature, packaged as a plugin (`ccw`) so I can use it across machines. It guides feature work through 8 phases:
 
 1. **Design** — Talk through the feature in conversation to clarify requirements, constraints, alternatives, and trade-offs. Produces an agreed summary, not yet a document.
-2. **Document** — Turn the agreed design into a polished markdown doc (default `docs/features/<name>/design.md`, or an external destination like Confluence).
+2. **Document** — Turn the agreed design into a polished markdown doc (default `.claude/ccw/<name>/design.md`, or an external destination like Confluence).
 3. **Plan** — Decompose the work into independently verifiable steps, each with an objective, scope, and verification method. On first run, captures the project's `test`/`lint` commands and creates the feature branch.
 4. **Implement** — Carry out the plan one step at a time. Each step is a mini-cycle: implement → run unit tests → user review → commit. One commit per approved step keeps the PR easy to read.
 5. **Verify** — Run integration-level checks against the complete implementation (integration tests, full suite, lint, type check) and diagnose/fix any failures.

--- a/docs/design/01-decisions.md
+++ b/docs/design/01-decisions.md
@@ -9,7 +9,7 @@ This file captures the design decisions made for `ccw` and the reasoning behind 
 | Version strategy | Explicit semver in `plugin.json`, manually bumped per release | Updates only roll out to other machines when version is bumped |
 | Skill structure | Hybrid (orchestrator + per-phase sub-skills) | Each phase can be invoked independently and reused |
 | Progress state storage | `.claude/ccw/<feature-name>/state.json` | Local metadata in the consuming project; gitignored |
-| Artifact storage (default) | `docs/features/<feature-name>/` | Treats design and plan documents as git-tracked assets |
+| Artifact storage (default) | `.claude/ccw/<feature-name>/` | Keeps all per-feature ccw output in one directory; git tracking is the user's choice (see `.gitignore` guidance in README) |
 | Artifact location prompt | Asked each time | Allows external destinations such as Confluence |
 | Autonomy level | User confirmation at every phase transition | Ensures the user can add input before progressing |
 | AI review tool | Instructs the user to run `/ultrareview` | The skill cannot invoke `/ultrareview` itself |

--- a/docs/design/03-layout.md
+++ b/docs/design/03-layout.md
@@ -45,20 +45,14 @@ claude-code-workflow/
 
 ## Per-Feature Workflow Working Directory (in the consuming project)
 
-Created by the plugin inside whatever project is using it.
+Created by the plugin inside whatever project is using it. By default, both metadata and artifacts live under the same directory:
 
 ```
 .claude/ccw/<feature-name>/
 ├── state.json    # Progress state
-└── config.json   # Verification commands and other settings
+├── config.json   # Verification commands and other settings
+├── design.md     # Default location for the design document
+└── plan.md       # Default location for the plan document
 ```
 
-## Artifact Directory (Default, in the consuming project)
-
-```
-docs/features/<feature-name>/
-├── design.md
-└── plan.md
-```
-
-> When the user chooses an external destination (e.g., Confluence), the skill outputs the markdown body and the user publishes it to the external system. The external location (URL, description, etc.) is recorded in `state.json` under `design_doc_external`.
+> When the user chooses an external destination (e.g., Confluence) for `design.md` or `plan.md`, the skill outputs the markdown body and the user publishes it to the external system. The external location (URL, description, etc.) is recorded in `state.json` under `design_doc_external`. In that case `design.md` / `plan.md` may be absent from this directory.

--- a/docs/design/04-distribution.md
+++ b/docs/design/04-distribution.md
@@ -14,7 +14,7 @@ Strict semver is awkward for an agentic plugin because behavior is partly non-de
 
 - Slash command names and arguments
 - `state.json` and `config.json` schemas (fields, names, allowed values)
-- Artifact paths and formats (e.g., `docs/features/<name>/design.md`)
+- Artifact paths and formats (e.g., `.claude/ccw/<name>/design.md`)
 - Phase list and phase order
 
 A change that removes/renames any of the above, or that breaks resuming an in-progress workflow created by an older version, is a **major** bump.

--- a/docs/design/05-state.md
+++ b/docs/design/05-state.md
@@ -11,17 +11,17 @@ The orchestrator and each sub-skill persist progress in `.claude/ccw/<feature-na
   "current_phase": "implement",
   "completed_phases": ["design", "document", "plan"],
   "config": {
-    "design_doc_path": "docs/features/user-auth/design.md",
+    "design_doc_path": ".claude/ccw/user-auth/design.md",
     "design_doc_external": null,
-    "plan_doc_path": "docs/features/user-auth/plan.md",
+    "plan_doc_path": ".claude/ccw/user-auth/plan.md",
     "test_command": "npm test",
     "lint_command": "npm run lint",
     "integration_test_command": "npm run test:integration",
     "branch_name": "feature/user-auth"
   },
   "artifacts": {
-    "design_doc": "docs/features/user-auth/design.md",
-    "plan_doc": "docs/features/user-auth/plan.md",
+    "design_doc": ".claude/ccw/user-auth/design.md",
+    "plan_doc": ".claude/ccw/user-auth/plan.md",
     "implementation_steps": [
       { "step": 1, "description": "Define schema", "status": "done" },
       { "step": 2, "description": "API endpoints", "status": "in_progress" },

--- a/docs/design/phases/document.md
+++ b/docs/design/phases/document.md
@@ -10,7 +10,7 @@ Turn the agreements from the `design` phase into a polished markdown document.
 
 ## Behavior
 
-1. Ask for the storage location (default `docs/features/<name>/design.md`, or external such as Confluence).
+1. Ask for the storage location (default `.claude/ccw/<name>/design.md`, or external such as Confluence).
 2. Write the markdown document.
 3. Ask the user to review and incorporate feedback.
 

--- a/docs/design/phases/plan.md
+++ b/docs/design/phases/plan.md
@@ -23,7 +23,7 @@ Decompose the implementation into well-defined, independently verifiable steps.
 
 ## Output
 
-- `plan.md` (in the chosen location, defaulting to `docs/features/<name>/plan.md`)
+- `plan.md` (in the chosen location, defaulting to `.claude/ccw/<name>/plan.md`)
 - `config.json` populated with verification commands
 - A new git branch
 - `state.json.artifacts.plan_doc` and `state.json.artifacts.implementation_steps` populated

--- a/skills/document/SKILL.md
+++ b/skills/document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: document
-description: Second phase of the ccw workflow. Turn the agreed design from the design phase into a polished markdown document. Asks the user where to save it (default docs/features/<feature>/design.md, or an external destination like Confluence). Use this when the user invokes /ccw:document directly, or when the orchestrator (/ccw:start) delegates the document phase.
+description: Second phase of the ccw workflow. Turn the agreed design from the design phase into a polished markdown document. Asks the user where to save it (default .claude/ccw/<feature>/design.md, or an external destination like Confluence). Use this when the user invokes /ccw:document directly, or when the orchestrator (/ccw:start) delegates the document phase.
 ---
 
 # /ccw:document — Design Documentation
@@ -15,7 +15,7 @@ Turn the notes accumulated during the `design` phase into a polished, self-conta
 
 1. Read state.json. If `notes` is empty, warn the user and suggest running `/ccw:design` first; do not proceed without their explicit confirmation.
 2. **Ask the user where to save the document**:
-   - Default: `docs/features/<feature-name>/design.md`
+   - Default: `.claude/ccw/<feature-name>/design.md`
    - External destination (Confluence, Notion, etc.) — in this case you will print the markdown body for the user to publish manually
 3. Compose the markdown document. Suggested structure:
    - Title (feature name)

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -18,7 +18,7 @@ Decompose the design into a sequence of small, independently verifiable steps th
    - Have a clear objective
    - Have a bounded scope of changes
    - Be independently verifiable (you should be able to describe the unit test up front)
-3. **Ask the user where to save the plan** (default `docs/features/<feature-name>/plan.md`).
+3. **Ask the user where to save the plan** (default `.claude/ccw/<feature-name>/plan.md`).
 4. Write the plan as a markdown document. Suggested structure:
    - Each step gets a heading: `## Step N: <objective>`
    - Under each: scope, files affected, verification method


### PR DESCRIPTION
## 요약
- `design.md`·`plan.md`의 기본 저장 위치를 `docs/features/<feature>/`에서 `.claude/ccw/<feature>/`로 변경
- 사용자에게 저장 위치를 묻는 흐름(Confluence 등 외부 destination 선택 가능)은 그대로 유지. 제안되는 디폴트만 바뀜
- 한 피쳐의 모든 ccw 산출물(`state.json`, `config.json`, `design.md`, `plan.md`)이 `.claude/ccw/<feature>/` 한 디렉터리에 모임

## 테스트 플랜
- [x] grep invariant: `! grep -rqn "docs/features" CLAUDE.md docs/ skills/ README.md` PASS
- [x] 전체 트래킹된 파일에서 `git grep "docs/features"` 0 matches
- [x] `/ultrareview`: findings 0건
- [x] 리뷰어: `docs/design/` 갱신이 `skills/` SKILL.md 갱신과 일관되는지 확인 (CLAUDE.md의 spec-first 컨벤션)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)