### PR TITLE
[#13] Exclude done workflows from /ccw:start discovery

### DIFF
--- a/docs/design/phases/start.md
+++ b/docs/design/phases/start.md
@@ -11,8 +11,15 @@ The orchestrator is the canonical entry point for the workflow. It walks the use
 
 ## Behavior
 
-1. Discover any in-progress workflows under `.claude/ccw/`.
-2. If one or more exist → ask the user whether to resume one or start a new one.
+1. Discover existing workflows by reading each `.claude/ccw/<name>/state.json`. Classify every entry into one of three buckets:
+   - **in-progress** — parses cleanly and `current_phase != "done"`
+   - **done** — parses cleanly and `current_phase == "done"`
+   - **broken** — `state.json` is missing, unreadable, unparseable, or lacks a usable `current_phase`
+2. Decide what to surface:
+   - **Done** workflows are silently excluded; never mention them.
+   - **Broken** entries are reported on a single separate warning line (e.g., `Warning: skipped N broken workflow state(s): <paths>`), but never offered for resume.
+   - If one or more **in-progress** workflows exist → ask the user whether to resume one or start a new one.
+   - If zero in-progress workflows remain, proceed straight to the new-feature flow without prompting.
 3. If starting new → ask for:
    - Feature name (used as the workflow directory name)
    - High-level idea (one or two sentences for context)

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -17,12 +17,19 @@ Each phase corresponds to a sub-skill: `ccw:design`, `ccw:document`, `ccw:plan`,
 
 ## Step 1 — Detect existing workflows
 
-1. Look in the current project for any `.claude/ccw/<feature-name>/state.json` files.
-2. If one or more exist, list them with their `feature_name` and `current_phase`.
-3. Ask the user:
+1. Find every `.claude/ccw/<feature-name>/state.json` in the current project.
+2. Classify each entry:
+   - **in-progress** — file parses as JSON and `current_phase` is a non-`"done"` value
+   - **done** — file parses as JSON and `current_phase == "done"`
+   - **broken** — file is missing, unreadable, unparseable, or has no usable `current_phase`
+3. **Silently drop done entries.** Never mention them to the user.
+4. If any **broken** entries exist, print a single warning line listing their paths — e.g.,
+   `Warning: skipped N broken workflow state(s): <path1>, <path2>`.
+   Do **not** offer them for resume.
+5. If one or more **in-progress** entries exist, list them with their `feature_name` and `current_phase`, then ask:
    - "Resume one of these?" (let them pick by name)
    - "Or start a new feature?"
-4. If none exist, proceed to Step 2.
+6. If zero **in-progress** entries remain, proceed straight to Step 2 without prompting. Do not say "no workflows found" when only done workflows exist — just move on.
 
 ## Step 2 — Start a new feature (if applicable)
 


### PR DESCRIPTION
## Summary
- Classify each `.claude/ccw/<name>/state.json` entry as in-progress / done / broken
- Silently drop `done` entries from the discovery list; never mention them
- Surface broken state files on a single warning line (separate from the resume list)
- If zero in-progress workflows remain, skip the resume prompt and proceed straight to the new-feature flow
- Spec (`docs/design/phases/start.md`) and orchestrator skill (`skills/start/SKILL.md`) updated together per the design-first convention

Closes #13

## Test plan
- [x] Run `/ccw:start` in a project with only `done` workflows → no mention of them, jumps straight to new-feature prompts
- [x] Run `/ccw:start` with a mix of in-progress and done → only in-progress are listed
- [x] Run `/ccw:start` with a malformed `state.json` → single warning line shown; entry not offered for resume
- [x] Run `/ccw:start` with no `.claude/ccw/` at all → unchanged behavior (proceeds to new-feature flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)