### PR TITLE
[#11] /ccw:ai-review에서 /ultrareview 제안 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is my personal Claude Code workflow for developing a feature, packaged as a
 3. **Plan** — Decompose the work into independently verifiable steps, each with an objective, scope, and verification method. On first run, captures the project's `test`/`lint` commands and creates the feature branch.
 4. **Implement** — Carry out the plan one step at a time. Each step is a mini-cycle: implement → run unit tests → user review → commit. One commit per approved step keeps the PR easy to read.
 5. **Verify** — Run integration-level checks against the complete implementation (integration tests, full suite, lint, type check) and diagnose/fix any failures.
-6. **AI review** — Ask the user to run `/ultrareview`, then summarize the feedback together, decide which items to address, and apply changes.
+6. **AI review** — Ask the user how they want to perform the AI review (self-review, sub-agent, external tool, or skip), then summarize the feedback together, decide which items to address, and apply changes.
 7. **User review** — Present a structured summary of all changes for a final human review, and apply any last feedback before the change becomes externally visible.
 8. **PR** — Create the pull request following Claude Code's PR protocol, then add development notes (trade-offs, known limitations, follow-ups) as PR comments so reviewers get the accumulated context.
 

--- a/docs/design/01-decisions.md
+++ b/docs/design/01-decisions.md
@@ -12,6 +12,6 @@ This file captures the design decisions made for `ccw` and the reasoning behind 
 | Artifact storage (default) | `.claude/ccw/<feature-name>/` | Keeps all per-feature ccw output in one directory; git tracking is the user's choice (see `.gitignore` guidance in README) |
 | Artifact location prompt | Asked each time | Allows external destinations such as Confluence |
 | Autonomy level | User confirmation at every phase transition | Ensures the user can add input before progressing |
-| AI review tool | Instructs the user to run `/ultrareview` | The skill cannot invoke `/ultrareview` itself |
+| AI review tool | Asks the user how to perform the review (no specific tool prescribed) | Lets each run pick the right approach — self-review, sub-agent, external tool, or skip — without locking in a single mechanism |
 | PR creation tool | `gh pr create` | Uses the standard Claude Code PR protocol |
 | Per-phase verification commands | Asked once on first run, stored in `config.json` | Reused across the same feature |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -15,7 +15,7 @@ The workflow consists of 8 phases:
 | 3 | `/ccw:plan` | Decompose the implementation into well-defined steps |
 | 4 | `/ccw:implement` | For each step: [implement → unit test → user review → commit], iterating |
 | 5 | `/ccw:verify` | Run integration tests and other checks against the full implementation |
-| 6 | `/ccw:ai-review` | AI-driven code review (e.g., `/ultrareview`) |
+| 6 | `/ccw:ai-review` | AI-driven code review (mechanism chosen at runtime — self-review, sub-agent, external tool, or skip) |
 | 7 | `/ccw:user-review` | The user personally reviews all changes |
 | 8 | `/ccw:pr` | Create the PR, including any noteworthy development notes as PR comments |
 

--- a/docs/design/phases/ai-review.md
+++ b/docs/design/phases/ai-review.md
@@ -10,8 +10,8 @@ Get an automated AI review of the implementation and decide which feedback to ap
 
 ## Behavior
 
-1. Ask the user to run `/ultrareview` (the skill cannot invoke `/ultrareview` itself).
-2. When the user shares the results, summarize and organize them.
+1. Ask the user how they would like to perform the AI review. No specific tool is prescribed — they may request a self-review by the assistant, delegate to a sub-agent, paste feedback from an external review tool, or skip the phase entirely. Proceed according to their answer.
+2. When review feedback exists, summarize and organize it.
 3. Decide together which items to address vs. ignore.
 4. Apply code changes for items to address.
 
@@ -27,4 +27,4 @@ Get an automated AI review of the implementation and decide which feedback to ap
 ## Notes
 
 - AI review feedback is advisory, not mandatory. Trade-offs should be made explicit.
-- If `/ultrareview` is unavailable in the user's environment, this phase can be skipped — but the user must explicitly opt out.
+- The phase can be skipped — the user just signals skip when asked how they want to review.

--- a/docs/design/phases/ai-review.md
+++ b/docs/design/phases/ai-review.md
@@ -2,7 +2,7 @@
 
 Skill: `/ccw:ai-review`
 
-Get an automated AI review of the implementation and decide which feedback to apply.
+Get an AI review of the implementation and decide which feedback to apply.
 
 ## Input
 
@@ -10,7 +10,7 @@ Get an automated AI review of the implementation and decide which feedback to ap
 
 ## Behavior
 
-1. Ask the user how they would like to perform the AI review. No specific tool is prescribed — they may request a self-review by the assistant, delegate to a sub-agent, paste feedback from an external review tool, or skip the phase entirely. Proceed according to their answer.
+1. Ask the user how they would like to perform the AI review. No specific tool is prescribed — they may request a self-review by the assistant, delegate to a sub-agent, paste feedback from an external review tool, or skip the phase entirely. Proceed according to their answer. If the user chooses to skip, record the reason in `state.json.notes` and treat the phase as complete.
 2. When review feedback exists, summarize and organize it.
 3. Decide together which items to address vs. ignore.
 4. Apply code changes for items to address.
@@ -22,7 +22,7 @@ Get an automated AI review of the implementation and decide which feedback to ap
 
 ## Exit Condition
 
-- The user confirms the AI review feedback has been handled.
+- The user confirms the phase is complete (feedback addressed, or skipped).
 
 ## Notes
 

--- a/skills/ai-review/SKILL.md
+++ b/skills/ai-review/SKILL.md
@@ -5,7 +5,7 @@ description: Sixth phase of the ccw workflow. Ask the user how they want to perf
 
 # /ccw:ai-review — AI Review
 
-Get an automated AI review of the implementation and decide which feedback to apply.
+Get an AI review of the implementation and decide which feedback to apply.
 
 ## Inputs
 - The completed implementation (preferably committed to the feature branch)
@@ -30,7 +30,7 @@ Get an automated AI review of the implementation and decide which feedback to ap
 - Entries in `state.json.notes` describing items addressed and items intentionally skipped
 
 ## Exit condition
-The user confirms the AI review feedback has been handled.
+The user confirms the phase is complete (feedback addressed, or skipped).
 
 ## What NOT to do
 - Don't prescribe a specific review tool — ask the user how they want to review.

--- a/skills/ai-review/SKILL.md
+++ b/skills/ai-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-review
-description: Sixth phase of the ccw workflow. Get an AI review by asking the user to run /ultrareview, then summarize the results, decide together which items to address, and apply changes. Use this when the user invokes /ccw:ai-review directly, or when the orchestrator (/ccw:start) delegates the AI review phase.
+description: Sixth phase of the ccw workflow. Ask the user how they want to perform an AI review, obtain feedback (or accept skip), summarize the results, decide together which items to address, and apply changes. Use this when the user invokes /ccw:ai-review directly, or when the orchestrator (/ccw:start) delegates the AI review phase.
 ---
 
 # /ccw:ai-review — AI Review
@@ -13,8 +13,9 @@ Get an automated AI review of the implementation and decide which feedback to ap
 ## Procedure
 
 1. **Suggest committing** any uncommitted changes first, so the review covers a stable snapshot.
-2. **Ask the user to run `/ultrareview`** in this same session. You cannot invoke `/ultrareview` yourself — it must be user-triggered.
-3. When the user shares the review results, **summarize** them:
+2. **Ask the user how to perform the review.** No specific tool is prescribed. The user may request a self-review by the assistant, delegate to a sub-agent, paste feedback from an external review tool, or skip the phase. Proceed according to their answer.
+   - If the user chooses to skip, record the reason in `state.json.notes` (e.g., `"AI review skipped: <reason>"`) and treat the phase as complete.
+3. When review feedback exists, **summarize** it:
    - Group by severity (critical, important, nit)
    - Highlight items with concrete code references (file:line)
 4. **Discuss with the user** which items to address:
@@ -31,13 +32,7 @@ Get an automated AI review of the implementation and decide which feedback to ap
 ## Exit condition
 The user confirms the AI review feedback has been handled.
 
-## If /ultrareview is unavailable
-If the user reports `/ultrareview` is not available in their environment:
-1. Ask if they want to skip this phase or use an alternative review tool.
-2. If skipped, record explicitly in `state.json.notes` (e.g., `"AI review skipped: <reason>"`).
-3. Move on with explicit user opt-out — do not silently bypass.
-
 ## What NOT to do
-- Don't try to invoke `/ultrareview` yourself — instruct the user.
+- Don't prescribe a specific review tool — ask the user how they want to review.
 - Don't blindly apply all review feedback. Discuss trade-offs with the user.
 - Don't treat AI review feedback as mandatory; it's advisory.


### PR DESCRIPTION
## Summary
- `/ccw:ai-review` 단계에서 사용자에게 `/ultrareview` 실행을 안내하던 동작을 제거. 대신 사용자에게 리뷰 방식을 자유롭게 묻는다(self-review, sub-agent, 외부 도구, 스킵 등 — 특정 도구를 prescribe하지 않음).
- 동기: `/ultrareview`는 별도 USD 청구 라인이 있는 Claude Code 기능(cloud review)으로 확인됨. 이를 default로 안내하면 사용자가 의도치 않게 추가 과금 흐름으로 유도됨.
- 리뷰 결과 처리(severity 그루핑, address/skip/defer 결정, 수정 후 테스트 재실행)는 그대로 유지. 기본 리뷰 메커니즘의 prescription은 후속 작업으로 deferral.

## Test plan
- [x] `git grep -in ultrareview` 결과 zero hits
- [x] `skills/ai-review/SKILL.md`·`docs/design/phases/ai-review.md` 모두 `/ultrareview`를 prescribe하지 않고 새 자유 응답형 prompt를 설명
- [x] Spec/skill parity: design 문서와 skill이 동일한 동작(skip 처리 포함)을 기술
- [x] 최상위 `README.md`와 `docs/design/README.md`의 phase 표가 새 동작에 맞게 갱신
- [x] Closes #11