### PR TITLE
[#19] /ccw:ai-review 자동화 — 기록된 커밋 자체 리뷰

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,12 @@ Or `/reload-plugins` inside an active Claude Code session to pick up edits witho
 
 Prefix every commit message subject with `[#<issue_number>] ` to track the related issue. Example: `[#1] Add commit message convention to CLAUDE.md`. If you don't know the issue number, ask the user before committing.
 
+## Language convention
+
+Files that ship with the plugin must be written in English: everything under `docs/`, `skills/`, `README.md`, `CLAUDE.md`, and commit messages. The plugin is consumed by users of any locale, so prompts and documentation it emits stay locale-neutral.
+
+Files that are local to a single workflow run — primarily `state.json` and `config.json` under `.claude/ccw/<feature-name>/` of the consuming project — may follow whatever language the user is conversing in. These never ship with the plugin.
+
 ## Common tasks
 
 - **Add a new phase**: update `docs/design/02-architecture.md`, add `docs/design/phases/<new>.md`, update transitions and state values, then add `skills/<new>/SKILL.md`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is my personal Claude Code workflow for developing a feature, packaged as a
 3. **Plan** — Decompose the work into independently verifiable steps, each with an objective, scope, and verification method. On first run, captures the project's `test`/`lint` commands and creates the feature branch.
 4. **Implement** — Carry out the plan one step at a time. Each step is a mini-cycle: implement → run unit tests → user review → commit. One commit per approved step keeps the PR easy to read.
 5. **Verify** — Run integration-level checks against the complete implementation (integration tests, full suite, lint, type check) and diagnose/fix any failures.
-6. **AI review** — Ask the user how they want to perform the AI review (self-review, sub-agent, external tool, or skip), then summarize the feedback together, decide which items to address, and apply changes.
+6. **AI review** — Ask the user "proceed or skip". On proceed, the assistant self-reviews the commits recorded in `state.json.notes` for this workflow, summarizes findings, and applies the items the user agrees to address.
 7. **User review** — Present a structured summary of all changes for a final human review, and apply any last feedback before the change becomes externally visible.
 8. **PR** — Create the pull request following Claude Code's PR protocol, then add development notes (trade-offs, known limitations, follow-ups) as PR comments so reviewers get the accumulated context.
 

--- a/docs/design/01-decisions.md
+++ b/docs/design/01-decisions.md
@@ -12,6 +12,6 @@ This file captures the design decisions made for `ccw` and the reasoning behind 
 | Artifact storage (default) | `.claude/ccw/<feature-name>/` | Keeps all per-feature ccw output in one directory; git tracking is the user's choice (see `.gitignore` guidance in README) |
 | Artifact location prompt | Asked each time | Allows external destinations such as Confluence |
 | Autonomy level | User confirmation at every phase transition | Ensures the user can add input before progressing |
-| AI review tool | Asks the user how to perform the review (no specific tool prescribed) | Lets each run pick the right approach — self-review, sub-agent, external tool, or skip — without locking in a single mechanism |
+| AI review tool | Assistant self-reviews the commits recorded in `state.json.notes` for this workflow | The user is only asked "proceed or skip". No external tool is invoked. Removes a per-run decision in favor of a fixed, predictable mechanism |
 | PR creation tool | `gh pr create` | Uses the standard Claude Code PR protocol |
 | Per-phase verification commands | Asked once on first run, stored in `config.json` | Reused across the same feature |

--- a/docs/design/05-state.md
+++ b/docs/design/05-state.md
@@ -28,9 +28,19 @@ The orchestrator and each sub-skill persist progress in `.claude/ccw/<feature-na
       { "step": 3, "description": "Frontend integration", "status": "pending" }
     ]
   },
-  "notes": []
+  "notes": [
+    "[Implement] commit abc1234: [#42] Add user schema",
+    "[Verify] commit def5678: [#42] Fix flaky integration test"
+  ]
 }
 ```
+
+## `notes` conventions
+
+`notes` is a free-form append-only log used by the workflow. Two conventions are load-bearing:
+
+- **Commit records.** Phases that create commits (`implement`, `verify`, `ai-review`, `user-review`) append `"[<Phase>] commit <short-hash>: <subject>"` immediately after each commit. `ai-review` reads these to know which commits belong to the workflow.
+- **Decision/skip records.** Free-form notes describing design agreements, items intentionally skipped, etc. No format prescribed.
 
 ## Phase Values
 

--- a/docs/design/05-state.md
+++ b/docs/design/05-state.md
@@ -30,7 +30,7 @@ The orchestrator and each sub-skill persist progress in `.claude/ccw/<feature-na
   },
   "notes": [
     "[Implement] commit abc1234: [#42] Add user schema",
-    "[Verify] commit def5678: [#42] Fix flaky integration test"
+    "[Implement] commit def5678: [#42] Add API endpoints"
   ]
 }
 ```

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -15,7 +15,7 @@ The workflow consists of 8 phases:
 | 3 | `/ccw:plan` | Decompose the implementation into well-defined steps |
 | 4 | `/ccw:implement` | For each step: [implement → unit test → user review → commit], iterating |
 | 5 | `/ccw:verify` | Run integration tests and other checks against the full implementation |
-| 6 | `/ccw:ai-review` | AI-driven code review (mechanism chosen at runtime — self-review, sub-agent, external tool, or skip) |
+| 6 | `/ccw:ai-review` | Assistant self-reviews the commits recorded for this workflow (user only chooses proceed or skip) |
 | 7 | `/ccw:user-review` | The user personally reviews all changes |
 | 8 | `/ccw:pr` | Create the PR, including any noteworthy development notes as PR comments |
 

--- a/docs/design/phases/ai-review.md
+++ b/docs/design/phases/ai-review.md
@@ -11,7 +11,7 @@ Get an AI review of the implementation and decide which feedback to apply.
 ## Behavior
 
 1. Ask the user only **proceed or skip**.
-   - **proceed**: the assistant self-reviews the commits already recorded in `state.json.notes` for this workflow. The review subject is the union of those commits' diffs; no external tool is invoked.
+   - **proceed**: the assistant self-reviews the commits already recorded in `state.json.notes` for this workflow. The review subject is the union of those commits' diffs; no external tool is invoked. If no commits have been recorded yet, report it to the user and ask whether to skip or wait — do not pick a different review subject.
    - **skip**: record the reason in `state.json.notes` and treat the phase as complete.
 2. Summarize and organize the self-review feedback.
 3. Decide together which items to address vs. ignore.

--- a/docs/design/phases/ai-review.md
+++ b/docs/design/phases/ai-review.md
@@ -19,6 +19,7 @@ Get an AI review of the implementation and decide which feedback to apply.
 
 - Code changes addressing review feedback
 - A summary of items addressed and items intentionally skipped (with reasons)
+- Any fix committed during ai-review is appended to `state.json.notes` as `"[AI Review] commit <short-hash>: <subject>"`. Commits created in this run are not re-reviewed in the same run.
 
 ## Exit Condition
 

--- a/docs/design/phases/ai-review.md
+++ b/docs/design/phases/ai-review.md
@@ -10,10 +10,12 @@ Get an AI review of the implementation and decide which feedback to apply.
 
 ## Behavior
 
-1. Ask the user how they would like to perform the AI review. No specific tool is prescribed — they may request a self-review by the assistant, delegate to a sub-agent, paste feedback from an external review tool, or skip the phase entirely. Proceed according to their answer. If the user chooses to skip, record the reason in `state.json.notes` and treat the phase as complete.
-2. When review feedback exists, summarize and organize it.
+1. Ask the user only **proceed or skip**.
+   - **proceed**: the assistant self-reviews the commits already recorded in `state.json.notes` for this workflow. The review subject is the union of those commits' diffs; no external tool is invoked.
+   - **skip**: record the reason in `state.json.notes` and treat the phase as complete.
+2. Summarize and organize the self-review feedback.
 3. Decide together which items to address vs. ignore.
-4. Apply code changes for items to address.
+4. Apply code changes for items to address. Fix commits made during this run are not re-reviewed in the same run.
 
 ## Output
 
@@ -28,4 +30,4 @@ Get an AI review of the implementation and decide which feedback to apply.
 ## Notes
 
 - AI review feedback is advisory, not mandatory. Trade-offs should be made explicit.
-- The phase can be skipped — the user just signals skip when asked how they want to review.
+- The phase can be skipped — the user just answers "skip" at the prompt.

--- a/docs/design/phases/implement.md
+++ b/docs/design/phases/implement.md
@@ -27,6 +27,7 @@ Update `state.json.artifacts.implementation_steps[].status` as steps move from `
 - One commit per approved step
 - Code changes and unit tests
 - Updated `state.json` with step statuses
+- Each commit appended to `state.json.notes` as `"[Implement] commit <short-hash>: <subject>"` so later phases (notably `ai-review`) can locate the changes that belong to this workflow
 
 ## Exit Condition
 

--- a/docs/design/phases/user-review.md
+++ b/docs/design/phases/user-review.md
@@ -17,6 +17,7 @@ Give the user a structured opportunity to review the change before opening a PR.
 ## Output
 
 - Final code that the user is comfortable submitting
+- Any fix committed during user-review is appended to `state.json.notes` as `"[User Review] commit <short-hash>: <subject>"`
 
 ## Exit Condition
 

--- a/docs/design/phases/verify.md
+++ b/docs/design/phases/verify.md
@@ -18,6 +18,7 @@ Run integration-level checks against the complete implementation.
 ## Output
 
 - Verification report (summary of which checks passed/failed and any fixes applied)
+- Any fix committed during verify is appended to `state.json.notes` as `"[Verify] commit <short-hash>: <subject>"` so later phases (notably `ai-review`) can locate the changes that belong to this workflow
 
 ## Exit Condition
 

--- a/skills/ai-review/SKILL.md
+++ b/skills/ai-review/SKILL.md
@@ -18,6 +18,7 @@ Self-review the commits recorded for this workflow and decide which feedback to 
    - On **skip**, record the reason in `state.json.notes` (e.g., `"AI review skipped: <reason>"`) and treat the phase as complete. Stop here.
    - On **proceed**, continue.
 3. **Collect the review subject.** Read `state.json.notes` and extract every line matching `"[<Phase>] commit <short-hash>: <subject>"`. The set of `<short-hash>` values is the review subject. Snapshot this list at the start of the run — fix commits added later are not re-reviewed in the same run.
+   - If the snapshot is empty (no commits have been recorded yet for this workflow), report this to the user and ask whether to skip the phase or wait until commits exist. Do not invent a different review subject.
 4. **Self-review.** For each commit, read its diff (`git show <hash>`) and produce findings. Findings should be grouped by severity (critical, important, nit) with concrete code references (file:line) where possible.
 5. **Summarize** the findings for the user.
 6. **Discuss with the user** which items to address:

--- a/skills/ai-review/SKILL.md
+++ b/skills/ai-review/SKILL.md
@@ -1,30 +1,32 @@
 ---
 name: ai-review
-description: Sixth phase of the ccw workflow. Ask the user how they want to perform an AI review, obtain feedback (or accept skip), summarize the results, decide together which items to address, and apply changes. Use this when the user invokes /ccw:ai-review directly, or when the orchestrator (/ccw:start) delegates the AI review phase.
+description: Sixth phase of the ccw workflow. Ask the user only "proceed or skip". On proceed, self-review the commits recorded in state.json.notes for this workflow; on skip, record the reason and complete the phase. Use this when the user invokes /ccw:ai-review directly, or when the orchestrator (/ccw:start) delegates the AI review phase.
 ---
 
 # /ccw:ai-review — AI Review
 
-Get an AI review of the implementation and decide which feedback to apply.
+Self-review the commits recorded for this workflow and decide which feedback to apply.
 
 ## Inputs
 - The completed implementation (preferably committed to the feature branch)
+- `state.json.notes` entries of the form `"[<Phase>] commit <short-hash>: <subject>"` recorded by earlier phases
 
 ## Procedure
 
 1. **Suggest committing** any uncommitted changes first, so the review covers a stable snapshot.
-2. **Ask the user how to perform the review.** No specific tool is prescribed. The user may request a self-review by the assistant, delegate to a sub-agent, paste feedback from an external review tool, or skip the phase. Proceed according to their answer.
-   - If the user chooses to skip, record the reason in `state.json.notes` (e.g., `"AI review skipped: <reason>"`) and treat the phase as complete.
-3. When review feedback exists, **summarize** it:
-   - Group by severity (critical, important, nit)
-   - Highlight items with concrete code references (file:line)
-4. **Discuss with the user** which items to address:
+2. **Ask the user only "proceed or skip".**
+   - On **skip**, record the reason in `state.json.notes` (e.g., `"AI review skipped: <reason>"`) and treat the phase as complete. Stop here.
+   - On **proceed**, continue.
+3. **Collect the review subject.** Read `state.json.notes` and extract every line matching `"[<Phase>] commit <short-hash>: <subject>"`. The set of `<short-hash>` values is the review subject. Snapshot this list at the start of the run — fix commits added later are not re-reviewed in the same run.
+4. **Self-review.** For each commit, read its diff (`git show <hash>`) and produce findings. Findings should be grouped by severity (critical, important, nit) with concrete code references (file:line) where possible.
+5. **Summarize** the findings for the user.
+6. **Discuss with the user** which items to address:
    - For each item, propose: "address now" / "skip" / "defer to follow-up"
    - For "skip" or "defer", record the reason in `state.json.notes`
-5. **Apply changes** for items to address. After each fix:
+7. **Apply changes** for items to address. After each fix:
    - Re-run `config.test_command` to make sure nothing broke
    - If the fix is committed, append a one-line record to `state.json.notes` in the format `"[AI Review] commit <short-hash>: <subject>"` (use `git log -1 --pretty='%h %s'`). Commits made during the same ai-review run are not re-reviewed in this run.
-6. Summarize what was addressed and what was intentionally skipped.
+8. Summarize what was addressed and what was intentionally skipped.
 
 ## Output
 - Code changes addressing review feedback
@@ -34,6 +36,8 @@ Get an AI review of the implementation and decide which feedback to apply.
 The user confirms the phase is complete (feedback addressed, or skipped).
 
 ## What NOT to do
-- Don't prescribe a specific review tool — ask the user how they want to review.
+- Don't ask the user to choose a review mechanism — only "proceed or skip".
+- Don't invoke external review tools. The review is the assistant's own pass over the recorded commits.
 - Don't blindly apply all review feedback. Discuss trade-offs with the user.
 - Don't treat AI review feedback as mandatory; it's advisory.
+- Don't include commits outside the snapshotted list (e.g., commits from earlier merged work, or fix commits this run created).

--- a/skills/ai-review/SKILL.md
+++ b/skills/ai-review/SKILL.md
@@ -23,6 +23,7 @@ Get an AI review of the implementation and decide which feedback to apply.
    - For "skip" or "defer", record the reason in `state.json.notes`
 5. **Apply changes** for items to address. After each fix:
    - Re-run `config.test_command` to make sure nothing broke
+   - If the fix is committed, append a one-line record to `state.json.notes` in the format `"[AI Review] commit <short-hash>: <subject>"` (use `git log -1 --pretty='%h %s'`). Commits made during the same ai-review run are not re-reviewed in this run.
 6. Summarize what was addressed and what was intentionally skipped.
 
 ## Output

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -31,6 +31,7 @@ For each `implementation_step` in order (where `status != "done"`):
 5. **Branch on the user's response:**
    - **Approved** →
      - Create a commit containing only the changes for this step. Follow whatever commit-message conventions the consuming repo already uses (read recent `git log` to infer them); do not impose a format from this skill.
+     - Append a one-line record of the new commit to `state.json.notes` in the format `"[Implement] commit <short-hash>: <subject>"` (use `git log -1 --pretty='%h %s'` for the values). This record is the input ai-review reads later.
      - Mark the step as `done` in state.json.
      - Proceed to the next step (back to procedure 1 with the next step).
    - **Not approved** →

--- a/skills/user-review/SKILL.md
+++ b/skills/user-review/SKILL.md
@@ -26,6 +26,7 @@ Give the user a structured opportunity to review the change before it becomes ex
 4. If the user has feedback:
    - Apply the requested changes
    - Re-run `config.test_command` to make sure nothing broke
+   - If a fix is committed, append a one-line record to `state.json.notes` in the format `"[User Review] commit <short-hash>: <subject>"` (use `git log -1 --pretty='%h %s'`).
    - Re-summarize the affected portion
 5. Repeat steps 3–4 until the user explicitly approves moving to PR creation.
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -21,6 +21,7 @@ Run integration-level checks against the complete implementation. Per-step unit 
    - Diagnose the root cause
    - Fix it (or surface to the user if the fix isn't obvious)
    - Re-run **all** checks (not just the failing one)
+   - If a fix is committed, append a one-line record to `state.json.notes` in the format `"[Verify] commit <short-hash>: <subject>"` (use `git log -1 --pretty='%h %s'`). This record is the input ai-review reads later.
 5. When all checks pass, summarize for the user:
    - Which checks ran and passed
    - Any fixes applied during this phase


### PR DESCRIPTION
## Summary
- `/ccw:ai-review` 단계에서 "어떻게 리뷰할지" 묻던 동작을 제거하고, **"proceed or skip"** 두 선택지로 단순화. proceed 선택 시 어시스턴트가 `state.json.notes`에 기록된 이번 워크플로우 커밋들을 직접 자체 리뷰한다. 외부 도구(예: `/ultrareview`)를 호출하지 않는다.
- 자체 리뷰의 입력을 정의하기 위해, 커밋이 발생할 수 있는 4개 sub-skill (`implement`, `verify`, `ai-review`, `user-review`)이 커밋 직후 `[<Phase>] commit <short-hash>: <subject>` 한 줄을 `state.json.notes`에 append하도록 절차 추가. `docs/design/phases/*.md`와 `docs/design/05-state.md`에도 동일하게 문서화.
- 자체 리뷰는 시작 시점의 커밋 목록을 snapshot하여, 동일 ai-review 실행 안에서 만든 fix 커밋은 재리뷰하지 않음(자기 루프 방지). 기록된 커밋이 0개일 경우 사용자에게 보고 후 skip/대기 여부를 묻도록 명시.
- 동기: 기존 흐름은 매번 사용자에게 리뷰 방식을 묻게 되어 의사결정 부담이 큼. 자체 리뷰를 기본 메커니즘으로 고정하고 trigger를 단순화. (issue #19)
- 부수적으로, 작업 중 한글 leak 사례를 받아 `CLAUDE.md`에 plugin 파일은 영어로 작성한다는 컨벤션을 문서화 (한 commit, 사용자 추가 요청).

## Test plan
- [x] `! grep -rqn -e "Ask the user how to perform" -e "self-review, sub-agent, external tool" docs/ skills/ README.md` exit 0
- [x] `! grep -rqn -e "Ask the user how to perform" -e "self-review, sub-agent" docs/design/phases/ai-review.md skills/ai-review/SKILL.md` exit 0
- [x] 4개 SKILL.md (`implement`, `verify`, `ai-review`, `user-review`) 모두에 `state.json.notes` 기록 절차가 들어있는지 grep 통과
- [x] 4개 design phase 페이지에도 동일 컨벤션이 명시되었는지 grep 통과
- [x] `docs/design/01-decisions.md` "AI review tool" 행과 `docs/design/README.md` phases 표, `README.md` 6번 phase 설명 모두 새 동작에 맞게 갱신
- [x] 추적 파일 내 한글 0건 (`grep -rln "[가-힣]" docs/ skills/ README.md` empty)
- [x] Spec/skill parity: design 페이지와 SKILL.md가 동일한 동작(빈 snapshot 처리, 자기 루프 방지 포함)을 기술
- [x] Self-review 진행 (commit `6431799`에서 important findings 두 건 반영)
- [x] Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)